### PR TITLE
Fix typo that was breaking packaging

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -47,7 +47,7 @@ stacks  = [ "io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*" ]
   type = "Apache-2.0"
   uri  = "https://github.com/watchexec/watchexec/blob/main/LICENSE"
 
-[metdata]
+[metadata]
 pre-package   = "scripts/build.sh"
 include-files = [
     "LICENSE",


### PR DESCRIPTION
## Summary

Packaging was not including files because metadata section in manifest was not present due to typo.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
