### PR TITLE
Use musl libc static binary of watchexec

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -21,7 +21,7 @@ dependencies:
   id:              watchexec
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       watchexec-.+-x86_64-unknown-linux-gnu.tar.xz
+    glob:       watchexec-.+-x86_64-unknown-linux-musl.tar.xz
     owner:      watchexec
     repository: watchexec
     tag_filter: cli-v(1.*)

--- a/.github/workflows/update-watchexec-cli.yml
+++ b/.github/workflows/update-watchexec-cli.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
               with:
-                glob: watchexec-.+-x86_64-unknown-linux-gnu.tar.xz
+                glob: watchexec-.+-x86_64-unknown-linux-musl.tar.xz
                 owner: watchexec
                 repository: watchexec
                 tag_filter: cli-v(1.*)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -34,11 +34,11 @@ api = "0.7"
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:watchexec:watchexec:1.18.7:*:*:*:*:*:*:*"]
     id = "watchexec"
-    name = "Watchexec - execute commands when watched files change"
+    name = "Watchexec"
     purl = "pkg:generic/watchexec@1.18.7?arch=amd64"
-    sha256 = "1928c977bb7cacfa123c9064b53035c204b2fb41be7d84b29b7d15c5d50bccf1"
+    sha256 = "150754cf4b522dab468a2363d46fc852a0fb527c09120424d4484349bcf9f79b"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
-    uri = "https://github.com/watchexec/watchexec/releases/download/cli-v1.18.7/watchexec-1.18.7-x86_64-unknown-linux-gnu.tar.xz"
+    uri = "https://github.com/watchexec/watchexec/releases/download/cli-v1.18.7/watchexec-1.18.7-x86_64-unknown-linux-musl.tar.xz"
     version = "1.18.7"
 
     [[metadata.dependencies.licenses]]


### PR DESCRIPTION
## Summary

Using the version of watchexec compiled against gnu libc means that the base image needs to provide the expected version of gnu libc. This recently broke as the upstream project upgraded it's build system to a newer Ubuntu version.

In addition, this resolves #22 and unlocks running on the Tiny stack.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
