### PR TITLE
Removes ioutil package

### DIFF
--- a/watchexec/build_test.go
+++ b/watchexec/build_test.go
@@ -17,7 +17,6 @@
 package watchexec
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -37,7 +36,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "build")
+		ctx.Application.Path, err = os.MkdirTemp("", "build")
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "watchexec"})

--- a/watchexec/watchexec_test.go
+++ b/watchexec/watchexec_test.go
@@ -17,7 +17,6 @@
 package watchexec
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func testWatchexec(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "watchexec-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "watchexec-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
This package is deprecated as of go 1.16 so usage of it should be
removed

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
