### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/watchexec`
 
-The Paketo Watchexec Buildpack is a Cloud Native Buildpack that provides the Watchexec binary tool to support reloadable processes.
+The Paketo Buildpack for Watchexec is a Cloud Native Buildpack that provides the Watchexec binary tool to support reloadable processes.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/watchexec"
   id = "paketo-buildpacks/watchexec"
   keywords = ["watchexec", "reloadable", "processes"]
-  name = "Paketo Watchexec Buildpack"
+  name = "Paketo Buildpack for Watchexec"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Watchexec Buildpack' to 'Paketo Buildpack for Watchexec'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
