### PR TITLE
Add source info to dependency in buildpack.toml.

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -37,6 +37,8 @@ api = "0.7"
     name = "Watchexec"
     purl = "pkg:generic/watchexec@1.20.5?arch=amd64"
     sha256 = "33e091870736833b77b103a8e7268c0ae66d756b8d71203405353eb9d40774f2"
+    source = "https://github.com/watchexec/watchexec/releases/download/cli-v1.20.5/watchexec-1.20.5-x86_64-unknown-linux-musl.tar.xz"
+    source_sha256 = "33e091870736833b77b103a8e7268c0ae66d756b8d71203405353eb9d40774f2"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
     uri = "https://github.com/watchexec/watchexec/releases/download/cli-v1.20.5/watchexec-1.20.5-x86_64-unknown-linux-musl.tar.xz"
     version = "1.20.5"


### PR DESCRIPTION
## Summary

This PR adds the `source` and `source_sha256` fields to the dependency metadata in `buildpack.toml`. This enables tooling (e.g. provenance) which relies on these fields to be able to process this buildpack. While these fields are not a requirement codified in any RFC, they are prevalent across Paketo Buildpacks and as such have become a de-facto convention.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
