### PR TITLE
Fix ARM64 update jobs with the correct arch

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -40,3 +40,4 @@ dependencies:
     repository: watchexec
     tag_filter: v(1.*)
     token:      ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch:    arm64

--- a/.github/workflows/pb-update-watchexec-cli-arm-64.yml
+++ b/.github/workflows/pb-update-watchexec-cli-arm-64.yml
@@ -44,6 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
               with:
+                arch: arm64
                 glob: watchexec-.+-aarch64-unknown-linux-musl.tar.xz
                 owner: watchexec
                 repository: watchexec
@@ -93,7 +94,7 @@ jobs:
                 echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
                 echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
-                ARCH: ""
+                ARCH: arm64
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
                 ID: watchexec


### PR DESCRIPTION
## Summary

A quick fix to the pipeline descriptor to include the architecture information.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
