### PR TITLE
Update the version filter to accept the new 2.x version line

### DIFF
--- a/.github/workflows/pb-update-watchexec-cli-arm-64.yml
+++ b/.github/workflows/pb-update-watchexec-cli-arm-64.yml
@@ -31,7 +31,7 @@ jobs:
                 glob: watchexec-.+-aarch64-unknown-linux-musl.tar.xz
                 owner: watchexec
                 repository: watchexec
-                tag_filter: v(1.*)
+                tag_filter: v(2.*)
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-watchexec-cli.yml
+++ b/.github/workflows/pb-update-watchexec-cli.yml
@@ -30,7 +30,7 @@ jobs:
                 glob: watchexec-.+-x86_64-unknown-linux-musl.tar.xz
                 owner: watchexec
                 repository: watchexec
-                tag_filter: v(1.*)
+                tag_filter: v(2.*)
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - name: Update Buildpack Dependency
               id: buildpack


### PR DESCRIPTION
This version line help to resolve an issue that I was having with watchexec running on the Static Stack.

https://github.com/watchexec/watchexec/issues/814